### PR TITLE
Support for setting num rings from LaunchDarkly on the client.

### DIFF
--- a/app/components/ActiveCall/index.tsx
+++ b/app/components/ActiveCall/index.tsx
@@ -156,6 +156,10 @@ function Visualizer({
     const canvas = inputCanvasRef.current;
     const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (voiceSessionRef.current.state !== VoiceSessionState.LISTENING) {
+      // Don't show anything when not listening.
+      return;
+    }
     if (freqData) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const vu =

--- a/app/components/CallCharacter/index.tsx
+++ b/app/components/CallCharacter/index.tsx
@@ -210,10 +210,7 @@ export function CallCharacter({ character }: { character: CharacterType }) {
       character: character.characterId,
     });
     setStartingCall(true);
-    // Request wake lock if not already held.
-    if (released) {
-      request();
-    }
+    request();
     const session = makeVoiceSession({
       agentId: character.agentId,
       ttsVoice: character.voiceId,
@@ -304,7 +301,7 @@ export function CallCharacter({ character }: { character: CharacterType }) {
     setTimeout(() => {
       ringtone.play();
     }, 1000);
-  }, [character, model, released, request, ringtone, startingCall]);
+  }, [character, model, request, ringtone, startingCall]);
 
   // Invoked when ringtone is done ringing.
   const onRingtoneFinished = () => {


### PR DESCRIPTION
We can plumb this through via the server later, but as a stopgap, this change makes it possible to (a) play the ringtone multiple times, and (b) configure the number of rings (including zero) via LaunchDarkly.
