### PR TITLE
Defer starting ringtone until audio channel is connected.

### DIFF
--- a/app/components/CallCharacter/index.tsx
+++ b/app/components/CallCharacter/index.tsx
@@ -264,13 +264,15 @@ export function CallCharacter({ character }: { character: CharacterType }) {
 
     console.log(`CallCharacter: created voice session`);
     session.warmup();
-    session.startAudio(); // This will prompt for mic permission.
-
-    setVoiceSession(session);
-    // Wait a beat before starting the ringtone.
-    setTimeout(() => {
-      ringtone.play();
-    }, 1000);
+    // This will prompt for mic permission.
+    session.startAudio().then(() => {
+      // Starting audio session.
+      setVoiceSession(session);
+      // Wait a beat before starting the ringtone.
+      setTimeout(() => {
+        ringtone.play();
+      }, 1000);
+    });
   }, [character, model, isSupported, request, ringtone, startingCall]);
 
   // Invoked when ringtone is done ringing.

--- a/app/components/CallCharacter/index.tsx
+++ b/app/components/CallCharacter/index.tsx
@@ -108,6 +108,7 @@ export function CallCharacter({ character }: { character: CharacterType }) {
   const [callStartTime, setCallStartTime] = useState<number | null>(null);
   const router = useRouter();
   const model = searchParams.get("model") || llmModel;
+  const noRing = searchParams.get("ring") == "0" || false;
   const { isSupported, released, request, release } = useWakeLock({
     onRequest: () => console.log("Screen wake lock requested"),
     onError: () => console.error("Error with wake lock"),
@@ -268,17 +269,25 @@ export function CallCharacter({ character }: { character: CharacterType }) {
     session.startAudio().then(() => {
       // Starting audio session.
       setVoiceSession(session);
-      // Wait a beat before starting the ringtone.
-      setTimeout(() => {
-        ringtone.play();
-      }, 1000);
+      if (noRing) {
+        // Skip ringtone and get down to business.
+        setStartRequested(true);
+      } else {
+        // Wait a beat before starting the ringtone, which feels more natural.
+        setTimeout(() => {
+          ringtone.play();
+        }, 1000);
+      }
     });
-  }, [character, model, isSupported, request, ringtone, startingCall]);
+  }, [character, model, isSupported, request, ringtone, noRing, startingCall]);
 
   // Invoked when ringtone is done ringing.
   const onRingtoneFinished = () => {
     console.log(`CallCharacter: onRingtoneFinished`);
-    setStartRequested(true);
+    // Wait a bit before starting the voice session, so the ringtone doesn't get cut off.
+    setTimeout(() => {
+      setStartRequested(true);
+    }, 1000);
   };
 
   // Invoked when hangup sound effect is done playing.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,9 +2885,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fixie@npm:6.3.3-rc2":
-  version: 6.3.3-rc2
-  resolution: "fixie@npm:6.3.3-rc2"
+"fixie@npm:6.3.3":
+  version: 6.3.3
+  resolution: "fixie@npm:6.3.3"
   dependencies:
     "@apollo/client": ^3.8.1
     "@types/apollo-upload-client": ^17.0.2
@@ -2919,7 +2919,7 @@ __metadata:
       optional: true
   bin:
     fixie: src/main.js
-  checksum: 879772d61c3382b494edd71ce5bd3ac3fc0d370101387decce5067bbbdc03ac1a21e391dc3436a18b73e829d7d0a783216a2201d00391be30c43d6074d0b572d
+  checksum: a076873474416866a3ceecb329066ced9d1d8faf1623ba81d40397b3d1c6787fe2547a0a72b2de57836f6bc850e1ff3aef95c8b053e2a0e15065d246c60c9679
   languageName: node
   linkType: hard
 
@@ -3350,7 +3350,7 @@ __metadata:
     eslint: ^8
     eslint-config-next: ^14.0.3
     file-loader: ^6.2.0
-    fixie: 6.3.3-rc2
+    fixie: 6.3.3
     howler: ^2.2.4
     launchdarkly-js-client-sdk: ^3.1.4
     launchdarkly-react-client-sdk: ^3.0.9


### PR DESCRIPTION
While this means we can't overlap the ringtone with the rest of the setup, it should avoid the problem with the ringtone sounding jittery on phones especially.
