### PR TITLE
Remove hardcoded API key from image URL

### DIFF
--- a/app/components/Button-Interrupt/index.tsx
+++ b/app/components/Button-Interrupt/index.tsx
@@ -12,7 +12,7 @@ const InterruptButton = ({ currentCharacter }: ActiveCallProps) => {
       <div onClick={() => handleInterrupt('Interrupting...')} className="button-group">
         <img
           loading="lazy"
-          src="https://cdn.builder.io/api/v1/image/assets/TEMP/637201f93e5c91dc8330c44c3a7193e0bcc7c0202785613592d0b331a8298e2f?apiKey=9c0baa37d70d4f66ac9c7050ad355a6f&"
+          src="https://cdn.builder.io/api/v1/image/assets/TEMP/637201f93e5c91dc8330c44c3a7193e0bcc7c0202785613592d0b331a8298e2f"
           className="aspect-square object-contain object-center w-4 overflow-hidden shrink-0 max-w-full"
         />
         <div className="text-slate-800 text-sm tracking-wide self-center grow whitespace-nowrap my-auto">


### PR DESCRIPTION
## Summary
- Removes the hardcoded Builder.io API key from the interrupt button image URL in `Button-Interrupt/index.tsx`
- The CDN image serves the same SVG response with or without the `apiKey` query parameter
- Prepares the repo for open-sourcing by eliminating leaked credentials

## Test plan
- [ ] Verify the interrupt button image still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)